### PR TITLE
Fix gallery clearing when form validation fails

### DIFF
--- a/Form/AbstractMediaCollectionType.php
+++ b/Form/AbstractMediaCollectionType.php
@@ -81,6 +81,12 @@ class AbstractMediaCollectionType extends AbstractMediaType
 
         } elseif (is_array($inValue)) {
             $medias = $inValue;
+
+        } elseif (is_string($inValue) && $inValue !== '') {
+            $mediaData = json_decode($inValue, true);
+            if (is_array($mediaData) && isset($mediaData['medias'])) {
+                $medias = $this->filterRemovedMedias($this->getMedias($mediaData['medias']));
+            }
         }
 
         $structuredMedias = $this->mediaStructure->getStructure($medias, $options['thumbnail_filter'], true);


### PR DESCRIPTION
Проблема
При редактировании сущности с полем ImageCollectionType и отправке формы с ошибкой валидации в каком-нибудь другом поле, галерея отображалась пустой. После перезагрузки страницы изображения возвращались.

Причина
После ошибки валидации, поле value возвращает JSON-строку. Метод buildView() обрабатывал только Collection и array, поэтому при строковом $inValue массив $medias оставался пустым, и поле рендерилось без изображений.

Решение
В AbstractMediaCollectionType::buildView() добавлена обработка строки.
