### PR TITLE
Decode submitted JSON in view transformer instead of model transformer

### DIFF
--- a/Form/AbstractMediaCollectionType.php
+++ b/Form/AbstractMediaCollectionType.php
@@ -32,7 +32,7 @@ class AbstractMediaCollectionType extends AbstractMediaType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addModelTransformer(new CallbackTransformer(
+        $builder->addViewTransformer(new CallbackTransformer(
             function ($medias) {
                 return $medias;
             },

--- a/Form/AbstractMediaItemType.php
+++ b/Form/AbstractMediaItemType.php
@@ -31,7 +31,7 @@ class AbstractMediaItemType extends AbstractMediaType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addModelTransformer(new CallbackTransformer(
+        $builder->addViewTransformer(new CallbackTransformer(
             function ($media) {
                 return $media;
             },


### PR DESCRIPTION
Проблема
При редактировании формы с полем типа ImageCollectionType и отправке формы с ошибкой валидации в каком-нибудь другом поле, поле ImageCollectionType отображалось пустым. После перезагрузки страницы изображения возвращались.

Причина
После ошибки валидации, функция buildView() пытается обработать JSON-строку из параметра 'value', т.к. эта строка не была конвертирована в массив. buildView() обрабатывает только Collection или массивы, и строка не могла быть обработана.

Решение
В AbstractMediaCollectionType::buildForm() и AbstractMediaItemType::buildForm() трансформация данных из JSON строки в массив перенесена во ViewTransformer вместо ModelTransformer, благодаря чему buildView получает данные в правильном виде.